### PR TITLE
Install lvm2 package

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -7,6 +7,7 @@
   with_items:
     - system-storage-manager
     - sg3_utils
+    - lvm2
 
 - name: COMMAND | checking for scsi devices
   command: sg_scan


### PR DESCRIPTION
This was failing due to missing lvm command on CentOS 7 (using the official AMI, which I think is a pretty minimal install). PR includes lvm2 in the list of required packages.
