### PR TITLE
tasks/manage_lvm.yml: Moved filesytem resize feature to LVOL task & refactoring

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role to manage LVM Groups/Logical Volumes. Can be used to create, extend or resize LVM.
   company:
   license: BSD
-  min_ansible_version: 2.0
+  min_ansible_version: 2.5
   platforms:
   - name: EL
     versions:

--- a/tasks/manage_lvm.yml
+++ b/tasks/manage_lvm.yml
@@ -1,20 +1,22 @@
 ---
 
-- name: LVG | Creating new LVM volume group(s)
+- name: LVG | Manage LVM volume group(s)
   lvg:
     vg: "{{ item.vgname }}"
     pvs: "{{ item.disks }}"
-    state: present
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ lvm_groups }}"
   when: item.create is defined and item.create
 
-- name: LVOL | Creating new LVM logical volume(s)
+- name: LVOL | Manage LVM logical volume(s)
   lvol:
     vg: "{{ item.0.vgname }}"
     lv: "{{ item.1.lvname }}"
     size: "{{ item.1.size }}"
-    shrink: "{{ item.1.schrink | default(yes) }}"
-    state: present
+    resizefs: "{{ item.1.resizefs | default('yes') }}"
+    shrink: "{{ item.1.schrink | default('no') }}"
+    force: "{{ item.1.force | default('no') }}"
+    state: "{{ item.1.state | default('present') }}"
   register: lvm
   with_subelements:
     - "{{ lvm_groups }}"
@@ -28,7 +30,6 @@
   filesystem:
     fstype: "{{ item.1.filesystem }}"
     dev: "/dev/{{ item.0.vgname }}/{{ item.1.lvname }}"
-    resizefs: yes 
   with_subelements:
     - "{{ lvm_groups }}"
     - lvnames

--- a/tasks/manage_lvm.yml
+++ b/tasks/manage_lvm.yml
@@ -13,6 +13,7 @@
     vg: "{{ item.0.vgname }}"
     lv: "{{ item.1.lvname }}"
     size: "{{ item.1.size }}"
+    shrink: "{{ item.1.schrink | default(yes) }}"
     state: present
   register: lvm
   with_subelements:
@@ -27,7 +28,7 @@
   filesystem:
     fstype: "{{ item.1.filesystem }}"
     dev: "/dev/{{ item.0.vgname }}/{{ item.1.lvname }}"
-#    resizefs: yes  #coming in 2.0 which will replace the resizing filesystem task below
+    resizefs: yes 
   with_subelements:
     - "{{ lvm_groups }}"
     - lvnames
@@ -51,20 +52,6 @@
     (item.1 is defined and item.1 | length > 0 ) and
     (item.1.create is defined and item.1.create) and
     (item.1.mount is defined and item.1.mount)
-
-- name: COMMAND | Resizing filesystem
-  command: resize2fs /dev/{{ item.0.vgname }}/{{ item.1.lvname }}
-  with_subelements:
-    - "{{ lvm_groups }}"
-    - lvnames
-  when: lvm.changed and item.1.filesystem != "swap" and item.1.filesystem != "xfs"
-
-- name: COMMAND | Resizing xfs filesystem
-  command: xfs_growfs /dev/{{ item.0.vgname }}/{{ item.1.lvname }}
-  with_subelements:
-    - "{{ lvm_groups }}"
-    - lvnames
-  when: lvm.changed and item.1.filesystem == "xfs"
 
 - name: SHELL | Resizing swap
   shell: "swapoff -a && mkswap /dev/{{ item.0.vgname }}/{{ item.1.lvname }} && swapon -va"


### PR DESCRIPTION
 - Ansible 2.5 added support for resizing underlaying fs at lvol module.
    It enables to schrink filesystem, unlike filesytem module.

- Added option to define state of managed VGs and LVs (to remove them)

- Removed tasks which handled resising of filesystem, which became redudant 

- Updated minimum required ansible version