### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -1,13 +1,12 @@
 ---
 
 - name: YUM | Install lvm
-  yum: >
-    name={{ item }}
-    state=present
-  with_items:
-    - system-storage-manager
-    - sg3_utils
-    - lvm2
+  yum:
+    name:
+      - system-storage-manager
+      - sg3_utils
+      - lvm2
+    state: present
 
 - name: COMMAND | checking for scsi devices
   command: sg_scan

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,15 +1,16 @@
 ---
 
 - name: APT | Install packages
-  apt: >
-    pkg={{ item }}
-    update_cache=yes
-    cache_valid_time=3600
-    state=present
+  apt:
+    name:
+      - lvm2
+      - scsitools
+      - xfsprogs
+    update_cache: true
+    cache_valid_time: 3600
+    state: present
   with_items:
-     - lvm2
-     - scsitools
-     - xfsprogs
+
 
 - name: COMMAND | Checking for scsi devices
   command: sg_scan

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -11,7 +11,6 @@
     state: present
   with_items:
 
-
 - name: COMMAND | Checking for scsi devices
   command: sg_scan
   register: scsi_devices


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated.
Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name:
['system-storage-manager', 'sg3_utils', 'lvm2']` and remove the loop. This feature will be removed in
version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.```